### PR TITLE
Support for new JDBC connector Snowflake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .history
 .DS_Store
+target/

--- a/connectors/presto/presto-snowflake/pom.xml
+++ b/connectors/presto/presto-snowflake/pom.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.288-SNAPSHOT</version>
+    </parent>
+    <artifactId>presto-snowflake</artifactId>
+    <description>Presto - snowflake Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <!--suppress UnresolvedMavenProperty -->
+        <!-- TODO: Resolve issue https://github.com/IBM/watsonx-data/issues/5 -->
+        <air.check.skip-enforcer>true</air.check.skip-enforcer>
+        <air.check.skip-dependency>false</air.check.skip-dependency>
+        <air.checkstyle.config-file>../src/checkstyle/presto-checks.xml</air.checkstyle.config-file>
+    </properties>
+
+    <dependencies>
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+     
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <version>3.13.29</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.airlift.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>skip-snowflake-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skipTests>${skipSnowflakeTests}</skipTests>
+                        </configuration>
+                    </plugin>              
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredClassPatterns>
+                        <ignoredClassPattern>META-INF.versions.9.module-info</ignoredClassPattern>
+                        <ignoredClassPattern> module-info</ignoredClassPattern>
+                    </ignoredClassPatterns>
+                </configuration>
+            </plugin> 
+            <plugin>
+                <groupId>org.gaul</groupId>
+                <artifactId>modernizer-maven-plugin</artifactId>
+                <configuration>
+                    <violationsFiles>
+                        <violationsFile>../src/modernizer/violations.xml</violationsFile>
+                    </violationsFiles>
+                    <exclusionPatterns>
+                        <exclusionPattern>org/joda/time/.*</exclusionPattern>
+                    </exclusionPatterns>
+                </configuration>
+            </plugin>                       
+        </plugins>
+    </build>
+</project>

--- a/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakeClient.java
+++ b/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakeClient.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcClient;
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
+import com.facebook.presto.spi.ConnectorSession;
+import net.snowflake.client.jdbc.SnowflakeDriver;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+public class SnowflakeClient
+        extends BaseJdbcClient
+{
+    @Inject
+    public SnowflakeClient(JdbcConnectorId connectorId, BaseJdbcConfig config)
+    {
+        super(connectorId, config, "\"", new DriverConnectionFactory(new SnowflakeDriver(), config));
+    }
+
+    @Override
+    public PreparedStatement getPreparedStatement(ConnectorSession session, Connection connection, String sql)
+            throws SQLException
+    {
+        connection.setAutoCommit(false);
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(1000);
+        return statement;
+    }
+}

--- a/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakeClientModule.java
+++ b/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakeClientModule.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class SnowflakeClientModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(JdbcClient.class).to(SnowflakeClient.class).in(Scopes.SINGLETON);
+        configBinder(binder).bindConfig(BaseJdbcConfig.class);
+    }
+}

--- a/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakePlugin.java
+++ b/connectors/presto/presto-snowflake/src/main/java/com/facebook/presto/plugin/snowflake/SnowflakePlugin.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import com.facebook.presto.plugin.jdbc.JdbcPlugin;
+
+public class SnowflakePlugin
+        extends JdbcPlugin
+{
+    public SnowflakePlugin()
+    {
+        super("snowflake", new SnowflakeClientModule());
+    }
+}

--- a/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestSnowflakeConnectorTest.java
+++ b/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestSnowflakeConnectorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.TEST_URL;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.dropTable;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.dropTableIfExists;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.execute;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.executeAndGetCount;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.getProperties;
+import static com.facebook.presto.plugin.snowflake.TestingSnowflakeServer.randomNameSuffix;
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class TestSnowflakeConnectorTest
+{
+    @Test
+    protected void testCreateTableWithDefaultColumns()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_create_table_with_default_columns_" + randomNameSuffix();
+        dropTableIfExists(url, tableName);
+        String createTableWithDefaultColumnSql = "CREATE TABLE " + tableName + " IF NOT EXISTS ( col_required BIGINT NOT NULL, col_nullable BIGINT, " +
+                "col_default BIGINT DEFAULT 43, " +
+                "col_nonnull_default BIGINT NOT NULL DEFAULT 42," +
+                "col_required2 BIGINT NOT NULL )";
+        execute(url, getProperties(), createTableWithDefaultColumnSql);
+        dropTable(url, tableName);
+    }
+
+    @Test
+    public void testInsert()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_insert_" + randomNameSuffix();
+        dropTableIfExists(url, tableName);
+        String createTableSQL = "CREATE TABLE " + tableName + " AS SELECT 123 x";
+        execute(url, getProperties(), createTableSQL);
+        String insertSQL = "INSERT INTO " + tableName + " (x) VALUES (456)";
+        execute(url, getProperties(), insertSQL);
+        dropTable(url, tableName);
+    }
+
+    @Test
+    public void testAlterTableRenameColumn()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_rename_column_" + randomNameSuffix();
+        String validTargetColumnName = "xyz_" + randomNameSuffix();
+        dropTableIfExists(url, tableName);
+        String createTableSQL = "CREATE TABLE " + tableName + " AS SELECT 123 AS x";
+        execute(url, getProperties(), createTableSQL);
+        String renameColumnSQL = "ALTER TABLE " + tableName + " RENAME COLUMN x TO " + validTargetColumnName;
+        execute(url, getProperties(), renameColumnSQL);
+        String selectTableSQL = "SELECT " + validTargetColumnName + " FROM " + tableName;
+        execute(url, getProperties(), selectTableSQL);
+        dropTable(url, tableName);
+    }
+
+    @Test
+    public void testAlterTableRenameTable()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_rename_" + randomNameSuffix();
+        String newTableName = "new_table_" + randomNameSuffix();
+        dropTableIfExists(url, tableName);
+        dropTableIfExists(url, newTableName);
+        String createTableSQL = "CREATE TABLE " + tableName + " AS SELECT 123 AS x";
+        execute(url, getProperties(), createTableSQL);
+        String renameTableSQL = "ALTER TABLE " + tableName + " RENAME TO " + newTableName;
+        execute(url, getProperties(), renameTableSQL);
+        String selectTableSQL = "SELECT * FROM " + newTableName;
+        execute(url, getProperties(), selectTableSQL);
+        dropTable(url, newTableName);
+    }
+
+    @Test
+    public void testAlterTableAddColumn()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_add_column_" + randomNameSuffix();
+        String columnName = "new_column_" + randomNameSuffix();
+        String columnType = "INT";
+        dropTableIfExists(url, tableName);
+        String createTableSQL = "CREATE TABLE " + tableName + " AS SELECT 123 AS x";
+        execute(url, getProperties(), createTableSQL);
+        String alterTableSQL = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + columnType;
+        execute(url, getProperties(), alterTableSQL);
+        String selectTableSQL = "SELECT " + columnName + " FROM " + tableName;
+        execute(url, getProperties(), selectTableSQL);
+        dropTable(url, tableName);
+    }
+
+    @Test
+    public void testAlterTableDropColumn()
+    {
+        String url = TEST_URL;
+        String tableName = "test_table_drop_column_" + randomNameSuffix();
+        String defaultColumnName = "column_default_" + randomNameSuffix();
+        String columnName = "x_" + randomNameSuffix();
+        String columnType = "INT";
+        dropTableIfExists(url, tableName);
+        String createTableSQL = "CREATE TABLE " + tableName + " AS SELECT 123 AS " + defaultColumnName;
+        execute(url, getProperties(), createTableSQL);
+        String alterTableAddColumnSQL = "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + columnType;
+        execute(url, getProperties(), alterTableAddColumnSQL);
+        String alterTableSQL = "ALTER TABLE " + tableName + " DROP COLUMN " + columnName;
+        execute(url, getProperties(), alterTableSQL);
+        String checkColumnExistenceSQL = "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = '" + tableName + "' AND COLUMN_NAME = '" + columnName + "'";
+        int count = executeAndGetCount(url, getProperties(), checkColumnExistenceSQL);
+        dropTable(url, tableName);
+        assertEquals(count, 0);
+    }
+}

--- a/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestSnowflakePlugin.java
+++ b/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestSnowflakePlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class TestSnowflakePlugin
+{
+    @Test
+    public void testCreateConnector()
+    {
+        Plugin plugin = new SnowflakePlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        factory.create("test", ImmutableMap.of("connection-url", "jdbc:snowflake://test"), new TestingConnectorContext()).shutdown();
+    }
+}

--- a/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestingSnowflakeServer.java
+++ b/connectors/presto/presto-snowflake/src/test/java/com/facebook/presto/plugin/snowflake/TestingSnowflakeServer.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.snowflake;
+
+import com.facebook.airlift.log.Logger;
+
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static java.lang.Thread.sleep;
+import static java.util.Objects.requireNonNull;
+
+public class TestingSnowflakeServer
+{
+    private static final Logger logger = Logger.get(TestingSnowflakeServer.class);
+    private static final char[] ALPHABET = new char[36];
+
+    static {
+        for (int digit = 0; digit < 10; digit++) {
+            ALPHABET[digit] = (char) ('0' + digit);
+        }
+
+        for (int letter = 0; letter < 26; letter++) {
+            ALPHABET[10 + letter] = (char) ('a' + letter);
+        }
+    }
+    private static final int RANDOM_SUFFIX_LENGTH = 10;
+    private static final SecureRandom random = new SecureRandom();
+    public static final String TEST_URL = requireNonNull(System.getProperty("snowflake.test.server.url"), "snowflake.test.server.url is not set");
+    public static final String TEST_USER = requireNonNull(System.getProperty("snowflake.test.server.user"), "snowflake.test.server.user is not set");
+    public static final String TEST_PASSWORD = requireNonNull(System.getProperty("snowflake.test.server.password"), "snowflake.test.server.password is not set");
+    public static final String TEST_DATABASE = requireNonNull(System.getProperty("snowflake.test.server.database"), "snowflake.test.server.database is not set");
+    public static final String TEST_ROLE = requireNonNull(System.getProperty("snowflake.test.server.role"), "snowflake.test.server.role is not set");
+    public static final String TEST_SCHEMA = requireNonNull(System.getProperty("snowflake.test.server.schema"), "snowflake.test.server.schema is not set");
+
+    private TestingSnowflakeServer() {}
+
+    public static void execute(String sql)
+    {
+        execute(TEST_URL, getProperties(), sql);
+    }
+
+    public static void execute(String url, Properties properties, String sql)
+    {
+        try (Connection connection = getConnection(url, properties);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (SQLException | InterruptedException e) {
+            logger.error(e, "Failed to execute statement");
+            throw new RuntimeException(e);
+        }
+    }
+    public static int executeAndGetCount(String url, Properties properties, String query)
+    {
+        try (Connection connection = getConnection(url, properties);
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(query)) {
+            if (resultSet.next()) {
+                return resultSet.getInt(1);
+            }
+        }
+        catch (SQLException | InterruptedException e) {
+            logger.error(e, "Failed to execute statement and get count");
+            throw new RuntimeException(e);
+        }
+        return 0;
+    }
+
+    public static Connection getConnection(String url, Properties properties) throws SQLException, InterruptedException
+    {
+        for (int retries = 0; retries < 5; retries++) {
+            try {
+                return DriverManager.getConnection(url, properties);
+            }
+            catch (SQLException e) {
+                if (retries < 4) {
+                    logger.info(e + " Failed to establish connection after " + (retries + 1) + " retry attempt(s).");
+                }
+                //sleep between retries
+                sleep(ThreadLocalRandom.current().nextLong(1000) * (retries + 1));
+                logger.info("Retrying");
+            }
+        }
+        throw new SQLException("Failed to establish connection after all retry attempts");
+    }
+
+    public static void dropTable(String url, String tableName)
+    {
+        String dropTableSQL = "DROP TABLE " + tableName;
+        execute(url, getProperties(), dropTableSQL);
+    }
+
+    public static void dropTableIfExists(String url, String tableName)
+    {
+        String dropTableIfExistsSQL = "DROP TABLE IF EXISTS " + tableName;
+        execute(url, getProperties(), dropTableIfExistsSQL);
+    }
+    public static Properties getProperties()
+    {
+        Properties properties = new Properties();
+        properties.setProperty("user", TEST_USER);
+        properties.setProperty("password", TEST_PASSWORD);
+        properties.setProperty("db", TEST_DATABASE);
+        properties.setProperty("schema", TEST_SCHEMA);
+        properties.setProperty("role", TEST_ROLE);
+        properties.setProperty("schema", TEST_SCHEMA);
+        return properties;
+    }
+
+    public static String randomNameSuffix()
+    {
+        char[] chars = new char[RANDOM_SUFFIX_LENGTH];
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = ALPHABET[random.nextInt(ALPHABET.length)];
+        }
+        return new String(chars);
+    }
+}

--- a/connectors/presto/readme.md
+++ b/connectors/presto/readme.md
@@ -1,1 +1,124 @@
 # IBM created Presto connectors that may be useful to you
+
+## Snowflake connector
+
+### Overview
+
+Snowflake is a cloud-based data platform that allows users to store, analyze, and share data.
+
+The Snowflake connector allows querying and creating tables in an external
+Snowflake database. This can be used to join data between different
+systems like Snowflake and Hive, or between two different Snowflake accounts.
+
+### Connector Configuration
+
+To configure the Snowflake connector, create a catalog properties file in *etc/catalog* named, for example, *snowflake.properties*, to mount the Snowflake connector as the snowflake catalog. Create the file with the following contents, replacing the connection properties as appropriate for your setup:
+
+```
+connector.name=snowflake
+connection-url=jdbc:snowflake://<account_identifier>.snowflakecomputing.com/?db={dbname}  
+connection-user={username}
+connection-password={password}
+```
+
+The `connection-url` defines the connection information and parameters to pass to the Snowflake JDBC driver.
+
+Syntax: `jdbc:snowflake://<account_identifier>.snowflakecomputing.com/?<connection_params>`
+
+User has to provide only the `account_identifier`, and shouldn't include the prefix `.snowflakecomputing.com`
+
+The `connection-user` and `connection-password` are typically required and determine the user credentials for the connection.
+
+### SSL Configuration
+
+By default, connections to Snowflake use SSL.
+
+### Integrating the Snowflake Plugin to Presto
+
+1. Clone the repository [watsonx-data](https://github.com/IBM/watsonx-data).
+
+2. Navigate to the folder *watsonx-data/connectors/presto/presto-snowflake*.
+
+3. Run the following command to build the module:
+
+    `mvn clean install -DskipTests`
+
+4. Rename the directory *`presto-snowflake-<VERSION>-SNAPSHOT`* generated within the target folder, which holds the essential JARs, using the below command:
+
+    `mv presto-snowflake-<version>-SNAPSHOT snowflake`
+
+5. Place the folder within the plugins directory, located at *`presto-server-<VERSION>/plugin`*.  
+
+6. Create the file `snowflake.properties` at the following path `etc/catalog/snowflake.properties`, replacing the properties as appropriate.
+
+7. Append the property `allow-drop-table` to `true` in `etc/catalog/snowflake.properties` to allow dropping Snowflake tables from Presto via `DROP TABLE` (defaults to `false`).
+
+8. Run the Presto server:
+
+    `bin/launcher start`
+
+
+### Multiple Snowflake Databases or Accounts
+
+The Snowflake connector can only access a single database within
+a Snowflake account. Thus, if you have multiple Snowflake databases,
+or want to connect to multiple Snowflake accounts, you must configure
+multiple catalog entries of the Snowflake connector.
+
+To add another catalog, simply add another properties file to ``etc/catalog``
+with a different name, making sure it ends in ``.properties``. For example,
+if you name the property file ``sales.properties``, Presto creates a
+catalog named ``sales`` using the configured connector.
+
+### Querying Snowflake
+
+The Snowflake connector provides a schema for every Snowflake *database*.
+You can see the available Snowflake schemas by running ``SHOW SCHEMAS``::
+
+    SHOW SCHEMAS FROM snowflake;
+
+If you have a Snowflake schema named ``web``, you can view the tables
+in this schema by running ``SHOW TABLES``::
+
+    SHOW TABLES FROM snowflake.web;
+
+You can see a list of the columns in the ``clicks`` table in the ``web`` schema
+using either of the following::
+
+    DESCRIBE snowflake.web.clicks;
+    SHOW COLUMNS FROM snowflake.web.clicks;
+
+You can access the ``clicks`` table in the ``web`` schema::
+
+    SELECT * FROM snowflake.web.clicks;
+
+If you used a different name for your catalog properties file, use
+that catalog name instead of ``snowflake`` in the above examples.
+
+### Snowflake Connector Limitations
+
+The following SQL statements are not supported:
+
+- [CREATE SCHEMA](https://prestodb.io/docs/0.286/sql/create-schema.html) 
+- [ALTER SCHEMA](https://prestodb.io/docs/0.286/sql/alter-schema.html)
+- [GRANT](https://prestodb.io/docs/0.286/sql/grant.html)
+- [REVOKE](https://prestodb.io/docs/0.286/sql/revoke.html)
+- [SHOW ROLES](https://prestodb.io/docs/0.286/sql/show-roles.html)
+- [SHOW ROLE GRANTS](https://prestodb.io/docs/0.286/sql/show-role-grants.html)
+- [CREATE ROLE](https://prestodb.io/docs/0.286/sql/create-role.html)
+- [CREATE VIEW](https://prestodb.io/docs/0.286/sql/create-view.html)
+- [DROP SCHEMA](https://prestodb.io/docs/0.286/sql/drop-schema.html)
+- [DROP VIEW](https://prestodb.io/docs/0.286/sql/drop-view.html)
+- [TRUNCATE](https://prestodb.io/docs/0.286/sql/truncate.html)
+- [UPDATE](https://prestodb.io/docs/0.286/sql/update.html)
+- [DELETE](https://prestodb.io/docs/0.286/sql/delete.html)
+
+### Running the unit testcases in **presto-snowflake** module
+
+Run the following command from the *presto* root directory to run the unit testcases in the *presto-snowflake* module:
+
+```
+mvn test -pl presto-snowflake -Dsnowflake.test.server.url=jdbc:snowflake://<account_identifier>.snowflakecomputing.com/ -Dsnowflake.test.server.user={username} -Dsnowflake.test.server.password={password} -Dsnowflake.test.server.database={dbname} -Dsnowflake.test.server.warehouse={warehousename} -Dsnowflake.test.server.role={role} -Dsnowflake.test.server.schema={schema}
+```
+
+

--- a/connectors/presto/src/checkstyle/presto-checks.xml
+++ b/connectors/presto/src/checkstyle/presto-checks.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="FileTabCharacter" />
+    <module name="NewlineAtEndOfFile">
+        <property name="lineSeparator" value="lf" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\r" />
+        <property name="message" value="Line contains carriage return" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value=" \n" />
+        <property name="message" value="Line has trailing whitespace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\n" />
+        <property name="message" value="Multiple consecutive blank lines" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\Z" />
+        <property name="message" value="Blank line before end of file" />
+    </module>
+
+    <module name="RegexpMultiline">
+        <property name="format" value="\{\n\n" />
+        <property name="message" value="Blank line after opening brace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="\n\n\s*\}" />
+        <property name="message" value="Blank line before closing brace" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="[^;]\s\)+\s*[\{;,]?\s*\n" />
+        <property name="message" value="Whitespace character before closing parenthesis" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="->\s*\{\s+\}" />
+        <property name="message" value="Whitespace inside empty lambda body" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="(class|interface) ([a-zA-Z0-9_])+(&lt;.*&gt;)? (extends|implements)" />
+        <property name="message" value="No new line before extends/implements" />
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static .*\.(of|copyOf|valueOf);$" />
+        <property name="message" value="The following methods may not be statically imported: of, copyOf, valueOf" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static .*\.(all|none);$" />
+        <property name="message" value="The following methods may not be statically imported: all, none" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static (?!java\.lang\.String\.format;).*\.format;" />
+        <property name="message" value="Only 'format' from java.lang.String may be statically imported" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^import static java\.util\.Optional\." />
+        <property name="message" value="Members of Optional may not be statically imported" />
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^([^i]|i[^m]|im[^p]|imp[^o]|impo[^r]|impor[^t]|import[^ ]).*Objects\.requireNonNull" />
+        <property name="message" value="Objects.requireNonNull should only be used with static imports" />
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^([^i]|i[^m]|im[^p]|imp[^o]|impo[^r]|impor[^t]|import[^ ]).*Math\.toIntExact" />
+        <property name="message" value="Math.toIntExact should only be used with static imports" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.testng\.Assert;$" />
+        <property name="message" value="org.testng.Assert should only be used with static imports" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import com\.google\.common\.base\.MoreObjects;$" />
+        <property name="message" value="com.google.common.base.MoreObjects should only be used with static imports" />
+    </module>
+
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.jetbrains\.annotations\.NotNull;$" />
+        <property name="message" value="Not null is the default for the codebase and should not be annotated" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import org\.jetbrains\.annotations\.Nullable;$" />
+        <property name="message" value="Use javax.annotation.Nullable instead of org.jetbrains.annotations.Nullable" />
+    </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="^[ \t]*import static org\.testng\.AssertJUnit\." />
+        <property name="message" value="Use org.testng.Assert instead of org.testng.AssertJUnit" />
+    </module>
+
+    <module name="SuppressWarningsFilter" />
+
+    <module name="TreeWalker">
+        <module name="SuppressWarningsHolder" />
+
+        <module name="EmptyBlock">
+            <property name="option" value="text" />
+            <property name="tokens" value="
+                LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_IF,
+                LITERAL_FOR, LITERAL_TRY, LITERAL_WHILE, INSTANCE_INIT, STATIC_INIT" />
+        </module>
+        <module name="EmptyStatement" />
+        <module name="EmptyForInitializerPad" />
+        <module name="EmptyForIteratorPad">
+            <property name="option" value="space" />
+        </module>
+        <module name="MethodParamPad">
+            <property name="allowLineBreaks" value="true" />
+            <property name="option" value="nospace" />
+        </module>
+        <module name="ParenPad" />
+        <module name="TypecastParenPad" />
+        <module name="NeedBraces" />
+        <module name="LeftCurly">
+            <property name="option" value="nl" />
+            <property name="tokens" value="CLASS_DEF, CTOR_DEF, INTERFACE_DEF, METHOD_DEF" />
+        </module>
+        <module name="LeftCurly">
+            <property name="option" value="eol" />
+            <property name="tokens" value="
+                 LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR,
+                 LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE" />
+        </module>
+        <module name="RightCurly">
+            <property name="option" value="alone" />
+        </module>
+        <module name="GenericWhitespace" />
+        <module name="WhitespaceAfter" />
+        <module name="NoWhitespaceAfter" />
+        <module name="NoWhitespaceBefore" />
+        <module name="SingleSpaceSeparator" />
+        <module name="Indentation">
+            <property name="throwsIndent" value="8" />
+            <property name="lineWrappingIndentation" value="8" />
+        </module>
+
+        <module name="UpperEll" />
+        <module name="DefaultComesLast" />
+        <module name="ArrayTypeStyle" />
+        <module name="MultipleVariableDeclarations" />
+        <module name="ModifierOrder" />
+        <module name="OneStatementPerLine" />
+        <module name="StringLiteralEquality" />
+        <module name="MutableException" />
+        <module name="EqualsHashCode" />
+        <module name="InnerAssignment" />
+        <module name="InterfaceIsType" />
+        <module name="HideUtilityClassConstructor" />
+        <module name="ExplicitInitialization" />
+        <module name="OneTopLevelClass" />
+
+        <module name="MemberName" />
+        <module name="LocalVariableName" />
+        <module name="LocalFinalVariableName" />
+        <module name="TypeName" />
+        <module name="PackageName" />
+        <module name="ParameterName" />
+        <module name="StaticVariableName" />
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z][0-9]?$" />
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z][0-9]?$" />
+        </module>
+
+        <module name="AnnotationUseStyle">
+            <property name="trailingArrayComma" value="ignore" />
+        </module>
+
+        <module name="AvoidStarImport" />
+        <module name="RedundantImport" />
+        <module name="UnusedImports" />
+        <module name="ImportOrder">
+            <property name="groups" value="*,javax,java" />
+            <property name="separated" value="true" />
+            <property name="option" value="bottom" />
+            <property name="sortStaticImportsAlphabetically" value="true" />
+        </module>
+
+        <module name="WhitespaceAround">
+            <property name="allowEmptyConstructors" value="true" />
+            <property name="allowEmptyMethods" value="true" />
+            <property name="allowEmptyLambdas" value="true" />
+            <property name="ignoreEnhancedForColon" value="false" />
+            <property name="tokens" value="
+                ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN,
+                BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAND,
+                LAMBDA, LE, LITERAL_ASSERT, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+                LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH,
+                LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE,
+                LOR, LT, MINUS, MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL,
+                PLUS, PLUS_ASSIGN, QUESTION, SL, SLIST, SL_ASSIGN, SR, SR_ASSIGN,
+                STAR, STAR_ASSIGN, TYPE_EXTENSION_AND" />
+        </module>
+
+        <module name="WhitespaceAfter" />
+
+        <module name="NoWhitespaceAfter">
+            <property name="tokens" value="DOT" />
+            <property name="allowLineBreaks" value="false" />
+        </module>
+
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.weakref.jmx.internal" />
+            <property name="illegalPkgs" value="jersey.repackaged" />
+            <property name="illegalPkgs" value="jdk.nashorn.internal" />
+            <property name="illegalPkgs" value="jdk.internal" />
+            <!-- Added to avoid accidental imports of the Spark shaded guava library that lives under the org.spark_project.guava package -->
+            <!-- It seems unlikely that anything would need to be imported from the org.spark_project package, as it contains private or semi private API -->
+            <property name="illegalPkgs" value="org.spark_project" />
+        </module>
+
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value=".*\.\$internal" />
+            <property name="regexp" value="true" />
+        </module>
+    </module>
+</module>

--- a/connectors/presto/src/modernizer/violations.xml
+++ b/connectors/presto/src/modernizer/violations.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<modernizer>
+    <violation>
+        <name>java/lang/Class.newInstance:()Ljava/lang/Object;</name>
+        <version>1.1</version>
+        <comment>Prefer Class.getConstructor().newInstance()</comment>
+    </violation>
+
+    <violation>
+        <name>java/lang/String.toLowerCase:()Ljava/lang/String;</name>
+        <version>1.1</version>
+        <comment>Prefer String.toLowerCase(java.util.Locale)</comment>
+    </violation>
+
+    <violation>
+        <name>com/google/common/primitives/Ints.checkedCast:(J)I</name>
+        <version>1.8</version>
+        <comment>Prefer Math.toIntExact(long)</comment>
+    </violation>
+
+    <violation>
+        <name>org/testng/Assert.assertEquals:(Ljava/lang/Iterable;Ljava/lang/Iterable;)V</name>
+        <version>1.8</version>
+        <comment>Use com.facebook.presto.testing.assertions.Assert.assertEquals due to TestNG #543</comment>
+    </violation>
+
+    <violation>
+        <name>org/testng/Assert.assertEquals:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/String;)V</name>
+        <version>1.8</version>
+        <comment>Use com.facebook.presto.testing.assertions.Assert.assertEquals due to TestNG #543</comment>
+    </violation>
+
+    <violation>
+        <name>java/util/TimeZone.getTimeZone:(Ljava/lang/String;)Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid TimeZone.getTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(..)) instead, or TimeZone.getTimeZone(..., false).</comment>
+    </violation>
+
+    <violation>
+        <name>org/joda/time/DateTimeZone.toTimeZone:()Ljava/util/TimeZone;</name>
+        <version>1.8</version>
+        <comment>Avoid DateTimeZone.toTimeZone as it returns GMT for a zone not supported by the JVM. Use TimeZone.getTimeZone(ZoneId.of(dtz.getId())) instead.</comment>
+    </violation>
+
+</modernizer>


### PR DESCRIPTION
Snowflake database is a cloud-hosted relational database that is used to build data warehouses and combines the functions of traditional databases with new capabilities. This PR implements support for the Snowflake connector in Presto by introducing a new module presto-snowflake.

Adding support to the Snowflake connector allows querying and creating tables in an external Snowflake database through Presto. This can be used to join data between different systems like Snowflake and Hive, or between two different Snowflake accounts.

Following statements that are checked are supported by the Snowflake connector in Presto:

<img width="566" alt="Screenshot 2024-05-12 at 4 21 45 PM" src="https://github.com/IBM/watsonx-data/assets/121156476/604d010a-9377-4995-9560-30fd2439ec52">

Example SQL queries: [example_queries.txt](https://github.com/IBM/watsonx-data/files/15285946/example_queries.txt)