### PR TITLE
Snowflake connector: Update the parent version in pom.xml from 0.288-SNAPSHOT to 0.290

### DIFF
--- a/connectors/presto/presto-snowflake/pom.xml
+++ b/connectors/presto/presto-snowflake/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.facebook.presto</groupId>
         <artifactId>presto-root</artifactId>
-        <version>0.288-SNAPSHOT</version>
+        <version>0.290</version>
     </parent>
     <artifactId>presto-snowflake</artifactId>
     <description>Presto - snowflake Connector</description>


### PR DESCRIPTION
The current parent Presto version 0.288-SNAPSHOT is a development build, and is not available in Maven Central. Therefore, in this PR updating the parent version from 0.288-SNAPSHOT to 0.290 in the pom.xml. 